### PR TITLE
Make the pure-Python implementation extend ExtensionClass.Base like the C version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     - TOX_ENV=py34
     - TOX_ENV=pypy
     - TOX_ENV=pypy3
+install:
+    - pip install tox
 script:
     - tox -e $TOX_ENV
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: python
 sudo: false
-python:
-    - 2.6
-    - 2.7
-    - 3.2
-    - 3.3
-    - 3.4
-    - pypy
-    - pypy3
-install:
-    - pip install nose
+python: 2.7
+env:
+    - TOX_ENV=py26
+    - TOX_ENV=py27
+    - TOX_ENV=py32
+    - TOX_ENV=py33
+    - TOX_ENV=py34
+    - TOX_ENV=pypy
+    - TOX_ENV=pypy3
 script:
-    - nosetests
+    - tox -e $TOX_ENV
 notifications:
     email: false

--- a/setup.py
+++ b/setup.py
@@ -67,4 +67,5 @@ setup(
     install_requires=['ExtensionClass'],
     include_package_data=True,
     zip_safe=False,
+    test_suite="MultiMapping.tests",
     )

--- a/src/MultiMapping/_MultiMapping.c
+++ b/src/MultiMapping/_MultiMapping.c
@@ -139,10 +139,11 @@ MM_getattr(MMobject *self, char *name)
   return Py_FindMethod(MM_methods, (PyObject *)self, name);
 }
 
-static int
+static Py_ssize_t
 MM_length(MMobject *self)
 {
-  long l=0, el, i;
+  Py_ssize_t l=0;
+  long el, i;
   PyObject *e=0;
 
   UNLESS(-1 != (i=PyList_Size(self->data))) return -1;
@@ -156,7 +157,7 @@ MM_length(MMobject *self)
 }
 
 static PyMappingMethods MM_as_mapping = {
-	(inquiry)MM_length,		/*mp_length*/
+	(lenfunc)MM_length,		/*mp_length*/
 	(binaryfunc)MM_subscript,      	/*mp_subscript*/
 	(objobjargproc)NULL,		/*mp_ass_subscript*/
 };

--- a/src/MultiMapping/__init__.py
+++ b/src/MultiMapping/__init__.py
@@ -1,7 +1,8 @@
 import os
 
+from ExtensionClass import Base
 
-class MultiMapping:
+class MultiMapping(Base):
     __slots__ = ('__dicts__',)
 
     def __init__(self, *args):
@@ -38,6 +39,7 @@ class MultiMapping:
     def __len__(self):
         return sum(len(d) for d in self.__dicts__)
 
+pyMultiMapping = MultiMapping
 
 if 'PURE_PYTHON' not in os.environ:  # pragma no cover
     try:

--- a/src/MultiMapping/tests.py
+++ b/src/MultiMapping/tests.py
@@ -17,9 +17,12 @@ import unittest
 
 class TestMultiMapping(unittest.TestCase):
 
-    def _makeOne(self):
+    def _getTargetClass(self):
         from MultiMapping import MultiMapping
-        return MultiMapping()
+        return MultiMapping
+
+    def _makeOne(self):
+        return self._getTargetClass()()
 
     def test_push(self):
         m = self._makeOne()
@@ -63,10 +66,20 @@ class TestMultiMapping(unittest.TestCase):
         m.push({'spam': 1})
         self.assertEqual(len(m), 1)
 
+    def test_is_extension_class(self):
+        from ExtensionClass import Base
+        self.assertTrue(isinstance(self._makeOne(), Base))
+
+class TestPyMultiMapping(TestMultiMapping):
+
+    def _getTargetClass(self):
+        from MultiMapping import pyMultiMapping
+        return pyMultiMapping
 
 def test_suite():
     return unittest.TestSuite((
         unittest.makeSuite(TestMultiMapping),
+        unittest.makeSuite(TestPyMultiMapping),
         ))
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands =
     nosetests
 deps =
     nose
+    ExtensionClass
 
 [testenv:py27-pure]
 basepython =


### PR DESCRIPTION
Add tests for this, and also test the Python implementation even when the C implementation is available. 

Also correct a compilation warning:

```
_MultiMapping.c:159:2: warning: incompatible pointer types initializing 'lenfunc' (aka 'Py_ssize_t (*)(PyObject *)') with an expression of type 'inquiry' (aka 'int (*)(PyObject *)') [-Wincompatible-pointer-types]
        (inquiry)MM_length,             /*mp_length*/
        ^~~~~~~~~~~~~~~~~~
```
